### PR TITLE
fix: multiple typos in the risk SKOS

### DIFF
--- a/riskos.ttl
+++ b/riskos.ttl
@@ -1,11 +1,12 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix riskos: <https://w3id.org/riskos#> .
+@prefix : <https://w3id.org/riskos#> .
 
 # Risk
 :Risk a skos:Concept ;
 	skos:prefLabel "Risk"@en ;
-    skos:narrower :Description, :Level, :Source .
+    skos:narrower :RiskDescription, :RiskLevel, :RiskSource .
 :RiskDescription a skos:Concept ;
     skos:prefLabel "Description"@en ;
     skos:broader :Risk .
@@ -56,10 +57,10 @@
 # Risk Assessment
 :RiskAssessment a skos:Concept ;
 	skos:prefLabel "Risk Assessment"@en ;
-    skos:narrower :Identification, :Analysis, :Evaluation .
+    skos:narrower :RiskIdentification, :RiskAnalysis, :RiskEvaluation .
 :RiskIdentification a skos:Concept ;
 	skos:prefLabel "Risk Identification"@en ;
-    skos:narrower :Finding, :Recognising, :Describing ;
+    skos:narrower :RiskFinding, :RiskRecognising, :RiskDescribing ;
     skos:broader :RiskAssessment .
 :RiskFinding a skos:Concept ;
 	# discovery vs finding
@@ -69,7 +70,7 @@
     skos:prefLabel "Recognising Risk"@en ;
     skos:broader :RiskIdentification .
 :RiskDescribing a skos:Concept ;
-    skos:prefLabel "Describin Risk"@en ;
+    skos:prefLabel "Describing Risk"@en ;
     skos:broader :RiskIdentification .
 :RiskAnalysis a skos:Concept ;
 	skos:prefLabel "Analysis"@en ;
@@ -77,7 +78,7 @@
     skos:broader :RiskAssessment .
 :RiskLevelDetermination a skos:Concept ;
     skos:prefLabel "Determine Level of Risk"@en ;
-    skos:broader :Analysis .
+    skos:broader :RiskAnalysis .
 
 # Risk Events, Sources, Causes, and Consequences
 :RiskSource a skos:Concept ;
@@ -88,7 +89,7 @@
 	skos:broader :RiskSource .
 :Event a skos:Concept ;
     skos:prefLabel "Event"@en .
-:RiskEvent a skos:Conceopt ;
+:RiskEvent a skos:Concept ;
 	skos:prefLabel "Risk Event"@en ;
 	skos:broader :Event .
 :SusceptibilityToRiskSource a skos:Concept ;
@@ -96,7 +97,7 @@
 :Consequence a skos:Concept ;
     skos:prefLabel "Consequence of an Event"@en ;
     skos:broader :Event .
-:Cause a skos:Copncept ;
+:Cause a skos:Concept ;
 	skos:prefLabel "Cause of an Event"@en ;
 	skos:broader :Event .
 
@@ -108,8 +109,8 @@
 	skos:broader :EventLikelihood .
 :EventFrequency a skos:Concept ;
 	skos:prefLabel "Frequency of an Event"@en .
-:EventFrequencyOccurences a skos:Concept ;
-	skos:prefLabel "Event Frequency Occurences"@en ;
+:EventFrequencyOccurrences a skos:Concept ;
+	skos:prefLabel "Event Frequency Occurrences"@en ;
 	skos:broader :EventFrequency .
 :EventFrequencyPeriod a skos:Concept ;
 	skos:prefLabel "Event Frequency Period"@en ;
@@ -120,8 +121,8 @@
 
 :RiskMatrix a skos:Concept ;
 	skos:prefLabel "Matrix"@en .
-:RiskLevel a skos:Concept ;
-	skos:prefLabel "LevelOf"@en .
+:RiskLevelValue a skos:Concept ;
+	skos:prefLabel "Level Value"@en .
 :CombinedLikelihood a skos:Concept ;
 	skos:prefLabel "combinesLikelihood"@en .
 :CombinedConsequence a skos:Concept ;
@@ -143,19 +144,19 @@
 :RiskTreatmentMethod a skos:Concept ;
 	skos:prefLabel "Risk Treatment Method"@en ;
 	skos:broader :RiskTreatment .
-:EliminateRisk skos:Concept ;
+:EliminateRisk a skos:Concept ;
 	skos:prefLabel "Eliminate Risk"@en ;
 	skos:broader :RiskTreatmentMethod .
-:AvoidRisk skos:Concept ;
+:AvoidRisk a skos:Concept ;
 	skos:prefLabel "Avoid Risk"@en ;
 	skos:broader :RiskTreatmentMethod .
-:TransferRisk skos:Concept ;
+:TransferRisk a skos:Concept ;
 	skos:prefLabel "Transfer Risk"@en ;
 	skos:broader :RiskTreatmentMethod .
-:AcceptRisk skos:Concept ;
+:AcceptRisk a skos:Concept ;
 	skos:prefLabel "Accept Risk"@en ;
 	skos:broader :RiskTreatmentMethod .
-:ReduceRisk skos:Concept ;
+:ReduceRisk a skos:Concept ;
 	skos:prefLabel "Reduce Risk"@en ;
 	skos:broader :RiskTreatmentMethod .
 :RiskControl a skos:Concept ;


### PR DESCRIPTION
Summary of fixes:

- Fixed spelling on line 73: "Describin Risk" → "Describing Risk"
- Fixed typo on line 92: :RiskEvent a skos:Conceopt → :RiskEvent a skos:Concept
- Fixed typo on line 100: :Cause a skos:Copncept → :Cause a skos:Concept
- Fixed spelling on line 113: "Occurences" → "Occurrences"
- Fixed inconsistent references: Updated skos:narrower and skos:broader relationships to use proper concept names
- Fixed missing 'a' on line 147: :EliminateRisk skos:Concept → :EliminateRisk a skos:Concept
- Added missing prefix declaration: Added @prefix : <https://w3id.org/riskos#> .
- Resolved duplicate RiskLevel: Changed the second definition to :RiskLevelValue to avoid conflicts
- and other similar mistakes